### PR TITLE
fix the flaky test in JacksonUtilsTest.java

### DIFF
--- a/common/src/test/java/com/alibaba/nacos/common/utils/JacksonUtilsTest.java
+++ b/common/src/test/java/com/alibaba/nacos/common/utils/JacksonUtilsTest.java
@@ -39,6 +39,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -91,9 +92,37 @@ public class JacksonUtilsTest {
                 "[{\"key\":\"value\"}]".getBytes(),
                 JacksonUtils.toJsonBytes(Collections.singletonList(Collections.singletonMap("key", "value")))
         );
-        Assert.assertArrayEquals(
-                "{\"aLong\":0,\"aInteger\":1,\"aBoolean\":false}".getBytes(),
-                JacksonUtils.toJsonBytes(new TestOfAtomicObject())
+        Object atomicObject = new TestOfAtomicObject();
+        Assert.assertTrue(
+                Arrays.equals(
+                        "{\"aLong\":0,\"aInteger\":1,\"aBoolean\":false}".getBytes(),
+                        JacksonUtils.toJsonBytes(atomicObject)
+                    )
+                    ||
+                    Arrays.equals(
+                        "{\"aLong\":0,\"aBoolean\":false,\"aInteger\":1}".getBytes(),
+                        JacksonUtils.toJsonBytes(atomicObject)
+                    )
+                    ||
+                    Arrays.equals(
+                        "{\"aInteger\":1,\"aLong\":0,\"aBoolean\":false}".getBytes(),
+                        JacksonUtils.toJsonBytes(atomicObject)
+                    )
+                    ||
+                    Arrays.equals(
+                        "{\"aInteger\":1,\"aBoolean\":false,\"aLong\":0}".getBytes(),
+                        JacksonUtils.toJsonBytes(atomicObject)
+                    )
+                    ||
+                    Arrays.equals(
+                        "{\"aBoolean\":false,\"aInteger\":1,\"aLong\":0}".getBytes(),
+                        JacksonUtils.toJsonBytes(atomicObject)
+                    )
+                    ||
+                    Arrays.equals(
+                        "{\"aBoolean\":false,\"aLong\":0,\"aInteger\":1}".getBytes(),
+                        JacksonUtils.toJsonBytes(atomicObject)
+                    )
         );
         Assert.assertArrayEquals("{\"date\":1626192000000}".getBytes(), JacksonUtils.toJsonBytes(new TestOfDate()));
         // only public
@@ -102,9 +131,17 @@ public class JacksonUtilsTest {
                 JacksonUtils.toJsonBytes(new TestOfAccessModifier())
         );
         // getter is also recognized
-        Assert.assertArrayEquals(
-                "{\"value\":\"value\",\"key\":\"key\"}".getBytes(),
-                JacksonUtils.toJsonBytes(new TestOfGetter())
+        Object getter = new TestOfGetter();
+        Assert.assertTrue(
+                Arrays.equals(
+                    "{\"value\":\"value\",\"key\":\"key\"}".getBytes(),
+                    JacksonUtils.toJsonBytes(getter)
+                )
+                ||
+                    Arrays.equals(
+                        "{\"key\":\"key\",\"value\":\"value\"}".getBytes(),
+                        JacksonUtils.toJsonBytes(getter)
+                    )
         );
         // annotation available
         Assert.assertArrayEquals(


### PR DESCRIPTION
The test `JacksonUtilsTest.testToJsonBytes1` compares the `toJsonByte` result with a hardcoded string. However, the input (which is a dictionary) could be non-deterministic.

For example, given the hardcoded string is `"{\"a\":\"a\",\"b\":\"b\"}"` and input object is `{"a":"a", "b":"b"}` (a dictionary), the output of `toJson` could be `"{\"a\":\"a\",\"b\":\"b\"}"` or `"{\"b\":\"b\",\"a\":\"a\"}"` since the order of key-value pair may change.

This is triggered by an external library API `com.fasterxml.jackson.databind.introspect.AnnotatedFieldCollector._findFields`.

This PR proposes to list all the possibilities to fix this flaky issue.